### PR TITLE
Improve file navigation for code review tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Navigate, search, and edit large codebases, logs, and data files that exceed AI context limits.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/peteretelej/largefile/ci.yml?branch=main&logo=github)](https://github.com/peteretelej/largefile/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/peteretelej/largefile/branch/main/graph/badge.svg)](https://codecov.io/gh/peteretelej/largefile) [![PyPI version](https://img.shields.io/pypi/v/largefile.svg)](https://pypi.org/project/largefile/) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://img.shields.io/github/actions/workflow/status/peteretelej/largefile/ci.yml?branch=main&logo=github)](https://github.com/peteretelej/largefile/actions/workflows/ci.yml) [![PyPI version](https://img.shields.io/pypi/v/largefile.svg)](https://pypi.org/project/largefile/) [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Why Largefile?
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,12 +27,14 @@ Analyze file structure with semantic outline and search hints.
 **Signature:**
 ```python
 def get_overview(
-    absolute_file_path: str
+    absolute_file_path: str,
+    changed_lines: list[list[int | str]] | None = None,
 ) -> dict
 ```
 
 **Parameters:**
 - `absolute_file_path`: Absolute path to the file (required)
+- `changed_lines` (optional): List of changed line ranges from a diff. Each entry is `[start, end]` or `[start, end, type]` where `type` is `"added"`, `"modified"`, or `"removed"`. Defaults to `"modified"` when type is omitted. Example: `[[10, 15, "added"], [45, 52]]`.
 
 **Returns:** Dictionary with:
 - `line_count`: Total lines in file
@@ -43,6 +45,9 @@ def get_overview(
 - `long_lines`: Object with detailed long line statistics
 - `outline`: Hierarchical structure via Tree-sitter (if supported)
 - `search_hints`: Suggested search patterns for exploration
+- `changed_symbols` (int, when `changed_lines` provided): Number of outline symbols that overlap with changed lines
+
+When `changed_lines` is provided, each outline item gains a `changes` field: `"added"`, `"modified"`, `"removed"`, or `null`.
 
 **Long Lines Object:**
 ```python
@@ -69,6 +74,25 @@ else:
 # Check for long lines
 if overview["long_lines"]["has_long_lines"]:
     print(f"Warning: {overview['long_lines']['count']} lines exceed {overview['long_lines']['threshold']} chars")
+```
+
+**Diff-Aware Overview Example:**
+```python
+# Pass changed line ranges from a diff to highlight affected symbols
+overview = get_overview(
+    "/path/to/src/auth.py",
+    changed_lines=[[10, 15, "added"], [45, 52, "modified"]]
+)
+print(f"{overview['changed_symbols']} symbols affected by changes")
+
+# Each outline item includes a "changes" field when changed_lines is provided
+for item in overview["outline"]:
+    if item["changes"]:
+        print(f"{item['name']} ({item['type']}): {item['changes']}")
+# Output:
+# 2 symbols affected by changes
+# create_session (function): added
+# validate_token (function): modified
 ```
 
 ### search_content

--- a/docs/design.md
+++ b/docs/design.md
@@ -206,6 +206,7 @@ class FileOverview:
     has_long_lines: bool  # >1000 chars (triggers truncation)
     outline: List[OutlineItem]  # Hierarchical via Tree-sitter
     search_hints: List[str]  # Common patterns for exploration
+    changed_symbols: int = 0  # Count of symbols overlapping changed lines
 
 @dataclass
 class OutlineItem:
@@ -215,6 +216,7 @@ class OutlineItem:
     end_line: int
     children: List[OutlineItem]  # Nested structure
     line_count: int
+    changes: str | None = None  # "added", "modified", "removed", or None
 
 @dataclass
 class SearchResult:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -516,6 +516,47 @@ if input("Apply changes? (y/n): ") == "y":
 # revert_edit("/path/to/app.py")  # Instant recovery
 ```
 
+## Diff-Aware Code Review
+
+### Reviewing Changes with Targeted Symbol Navigation
+
+**AI Question:** *"I have a diff patch file. Can you review just the functions that changed in src/auth.py?"*
+
+**AI Assistant workflow:**
+1. Use `diffchunk list_chunks` to get file details with changed line ranges
+2. Pass those ranges as `changed_lines` to `get_overview`
+3. Focus review on symbols with non-null `changes`
+
+```python
+# Step 1: Get diff overview to identify changed files and line ranges
+chunks = list_chunks("/path/to/diff.patch")
+# file_details shows: src/auth.py has changes at lines 10-15, 45-52
+
+# Step 2: Get diff-aware overview
+overview = get_overview(
+    "/path/to/src/auth.py",
+    changed_lines=[[10, 15, "added"], [45, 52, "modified"]]
+)
+# Response includes:
+# {
+#   "changed_symbols": 2,
+#   "outline": [
+#     {"name": "validate_token", "type": "function", "line_number": 42,
+#      "end_line": 68, "changes": "modified"},
+#     {"name": "create_session", "type": "function", "line_number": 8,
+#      "end_line": 20, "changes": "added"},
+#     {"name": "logout", "type": "function", "line_number": 70,
+#      "end_line": 85, "changes": null}
+#   ]
+# }
+
+# Step 3: Focus review on changed functions
+changed = [s for s in overview["outline"] if s["changes"]]
+for symbol in changed:
+    code = read_content("/path/to/src/auth.py", offset=symbol["line_number"],
+                        limit=symbol["line_count"])
+```
+
 ---
 
 These examples demonstrate how AI assistants use the Largefile MCP Server to handle real-world scenarios with large files, from code analysis to refactoring to data processing, with robust error recovery and batch operations.

--- a/src/change_marker.py
+++ b/src/change_marker.py
@@ -1,0 +1,150 @@
+"""Change-marking logic for diff-aware file overviews.
+
+Classifies outline symbols as added, modified, or removed based on
+changed line ranges from a diff.
+"""
+
+from __future__ import annotations
+
+from .data_models import OutlineItem
+
+# (start_line, end_line, change_type)
+# change_type: "added" | "modified" | "removed"
+ChangedLineRange = tuple[int, int, str]
+
+_VALID_CHANGE_TYPES = frozenset({"added", "modified", "removed"})
+
+
+def parse_changed_lines(raw: list[list[int | str]]) -> list[ChangedLineRange]:
+    """Validate and convert JSON input to internal ``ChangedLineRange`` list.
+
+    Each element of *raw* is ``[start, end]`` or ``[start, end, type]``.
+    When *type* is omitted it defaults to ``"modified"``.
+
+    After validation the ranges are sorted by start line and adjacent /
+    overlapping ranges **of the same type** are merged.
+    """
+    validated: list[ChangedLineRange] = []
+
+    for entry in raw:
+        if not isinstance(entry, list | tuple) or len(entry) not in (2, 3):
+            raise ValueError(
+                f"Each entry must have 2 or 3 elements, got {len(entry) if isinstance(entry, list | tuple) else type(entry).__name__}"
+            )
+
+        start = entry[0]
+        end = entry[1]
+        change_type: str = str(entry[2]) if len(entry) == 3 else "modified"
+
+        if not isinstance(start, int) or not isinstance(end, int):
+            raise ValueError(
+                f"start and end must be integers, got {type(start).__name__} and {type(end).__name__}"
+            )
+        if start < 1:
+            raise ValueError(f"start must be >= 1, got {start}")
+        if start > end:
+            raise ValueError(f"start ({start}) must be <= end ({end})")
+        if change_type not in _VALID_CHANGE_TYPES:
+            raise ValueError(
+                f"type must be one of {sorted(_VALID_CHANGE_TYPES)}, got {change_type!r}"
+            )
+
+        validated.append((start, end, change_type))
+
+    # Sort by start line
+    validated.sort(key=lambda r: r[0])
+
+    # Merge overlapping / adjacent ranges of the same type
+    merged: list[ChangedLineRange] = []
+    for rng in validated:
+        if merged and merged[-1][2] == rng[2] and merged[-1][1] >= rng[0] - 1:
+            # Extend the previous range
+            prev = merged[-1]
+            merged[-1] = (prev[0], max(prev[1], rng[1]), prev[2])
+        else:
+            merged.append(rng)
+
+    return merged
+
+
+def classify_change(
+    symbol_start: int,
+    symbol_end: int,
+    changed_ranges: list[ChangedLineRange],
+) -> str | None:
+    """Determine the change classification for a single symbol.
+
+    Returns ``"added"``, ``"modified"``, ``"removed"``, or ``None``.
+    """
+    overlapping: list[ChangedLineRange] = [
+        r for r in changed_ranges if r[0] <= symbol_end and r[1] >= symbol_start
+    ]
+
+    if not overlapping:
+        return None
+
+    types = {r[2] for r in overlapping}
+
+    if types == {"removed"}:
+        return "removed"
+
+    if types == {"added"}:
+        # Check full coverage: compute union of overlapping added ranges
+        # clipped to symbol bounds
+        symbol_len = symbol_end - symbol_start + 1
+        covered = _union_coverage(overlapping, symbol_start, symbol_end)
+        if covered == symbol_len:
+            return "added"
+        return "modified"
+
+    # Mixed types
+    return "modified"
+
+
+def _union_coverage(
+    ranges: list[ChangedLineRange], clip_start: int, clip_end: int
+) -> int:
+    """Compute the total number of lines covered by *ranges* within [clip_start, clip_end]."""
+    clipped = []
+    for start, end, _ in ranges:
+        cs = max(start, clip_start)
+        ce = min(end, clip_end)
+        if cs <= ce:
+            clipped.append((cs, ce))
+
+    if not clipped:
+        return 0
+
+    clipped.sort()
+    total = 0
+    cur_start, cur_end = clipped[0]
+    for s, e in clipped[1:]:
+        if s <= cur_end + 1:
+            cur_end = max(cur_end, e)
+        else:
+            total += cur_end - cur_start + 1
+            cur_start, cur_end = s, e
+    total += cur_end - cur_start + 1
+    return total
+
+
+def mark_outline(
+    items: list[OutlineItem],
+    changed_ranges: list[ChangedLineRange],
+) -> tuple[list[OutlineItem], int]:
+    """Classify each item in a flat outline list and set its ``changes`` field.
+
+    The list returned by ``generate_outline()`` is already flattened via
+    ``_flatten_outline_items()``, so children appear as top-level entries.
+    This function does **not** recurse into ``item.children`` to avoid
+    double-counting.
+
+    Returns ``(items, changed_count)`` - items are mutated in place.
+    """
+    changed_count = 0
+    for item in items:
+        result = classify_change(item.line_number, item.end_line, changed_ranges)
+        item.changes = result
+        if result is not None:
+            changed_count += 1
+    return items, changed_count

--- a/src/data_models.py
+++ b/src/data_models.py
@@ -62,6 +62,7 @@ class FileOverview:
     binary_hint: str | None
     outline: list["OutlineItem"]
     search_hints: list[str]
+    changed_symbols: int = 0
 
 
 @dataclass
@@ -72,6 +73,7 @@ class OutlineItem:
     end_line: int
     children: list["OutlineItem"]
     line_count: int
+    changes: str | None = None  # "added" | "modified" | "removed" | None
 
 
 @dataclass

--- a/src/server.py
+++ b/src/server.py
@@ -179,6 +179,50 @@ def read_content(
 
 
 @mcp.tool(
+    annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+    structured_output=False,
+)
+def read_enclosing(
+    absolute_file_path: Annotated[
+        str,
+        Field(description="Absolute path to target file"),
+    ],
+    line: Annotated[
+        int,
+        Field(description="Line number to find the enclosing function/class for", ge=1),
+    ],
+    depth: Annotated[
+        int,
+        Field(
+            description="Nesting depth: 1 = innermost definition, 2 = parent (e.g., class containing a method)",
+            ge=1,
+        ),
+    ] = 1,
+    context_lines: Annotated[
+        int,
+        Field(
+            description="Lines of context for fallback window when no enclosing definition is found",
+            ge=1,
+        ),
+    ] = 40,
+) -> dict:
+    """Find the enclosing function or class for a specific line number.
+
+    Given a file and line number, returns the complete enclosing definition
+    (function, method, class, struct, etc.) containing that line. Use depth=2
+    to get the parent definition (e.g., the class containing a method).
+    Falls back to a centered context window for unsupported languages or
+    top-level code.
+    """
+    return tools.read_enclosing(  # type: ignore[no-any-return]
+        absolute_file_path,
+        line=line,
+        depth=depth,
+        context_lines=context_lines,
+    )
+
+
+@mcp.tool(
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
     structured_output=False,
 )

--- a/src/server.py
+++ b/src/server.py
@@ -32,6 +32,16 @@ def get_overview(
             description="Absolute path to target file (e.g., /path/to/large_module.py)"
         ),
     ],
+    changed_lines: Annotated[
+        list[list[int | str]] | None,
+        Field(
+            description="Optional list of changed line ranges from a diff. "
+            "Each entry is [start, end] or [start, end, type] where type is "
+            '"added", "modified", or "removed". '
+            'Example: [[10, 15, "added"], [45, 52]]. '
+            "Available from diffchunk list_chunks file_details output."
+        ),
+    ] = None,
 ) -> dict:
     """Get file structure, size, and semantic outline for large files (code, logs, data).
 
@@ -41,7 +51,7 @@ def get_overview(
     files, uses Tree-sitter to extract functions, classes, and structure. Does
     NOT return file content - use read_content or search_content for that.
     """
-    return tools.get_overview(absolute_file_path)  # type: ignore[no-any-return]
+    return tools.get_overview(absolute_file_path, changed_lines=changed_lines)  # type: ignore[no-any-return]
 
 
 @mcp.tool(

--- a/src/tools.py
+++ b/src/tools.py
@@ -93,15 +93,26 @@ def get_overview(
     Detects binary files and long lines, returns search hints for efficient
     exploration.
 
+    Optionally accepts changed_lines to mark which symbols in the outline
+    contain changes from a diff, enabling diff-aware code review.
+
     CRITICAL: You must use an absolute file path - relative paths will fail.
     DO NOT attempt to read large files directly as they exceed context limits.
 
     Parameters:
     - absolute_file_path: Absolute path to the file
+    - changed_lines: Optional list of changed line ranges from a diff.
+      Each entry is [start, end] or [start, end, type] where type is
+      "added", "modified", or "removed" (defaults to "modified").
+      Example: [[10, 15, "added"], [45, 52, "modified"]] or [[10, 15]].
+      Available from diffchunk list_chunks file_details output.
 
     Returns:
     - FileOverview with line count, file size, detected encoding, binary detection,
       long line statistics, and search hints
+    - When changed_lines is provided, each outline item includes a "changes" field
+      ("added", "modified", "removed", or null) and the response includes
+      "changed_symbols" count
     """
     canonical_path = normalize_path(absolute_file_path)
     file_info = get_file_info(canonical_path)

--- a/src/tools.py
+++ b/src/tools.py
@@ -567,6 +567,9 @@ def read_enclosing(
     # Fallback: centered context window
     start = max(1, line - context_lines // 2)
     end = min(total_lines, start + context_lines - 1)
+    # Backfill: shift start backward when clipped at EOF
+    if end - start + 1 < context_lines:
+        start = max(1, end - context_lines + 1)
     content_text = "".join(lines[start - 1 : end])
     return {
         "content": content_text,

--- a/src/tools.py
+++ b/src/tools.py
@@ -42,6 +42,7 @@ from .file_access import (
 from .search_engine import search_file
 from .tree_parser import (
     extract_semantic_context,
+    find_enclosing_definition,
     generate_outline,
     get_semantic_chunk,
     parse_file_content,
@@ -506,6 +507,76 @@ def read_content(
     if warnings:
         result["warnings"] = warnings
     return result
+
+
+@handle_tool_errors
+def read_enclosing(
+    absolute_file_path: str,
+    line: int,
+    depth: int = 1,
+    context_lines: int = 40,
+) -> dict:
+    """Find the enclosing function or class for a specific line number.
+
+    Given a file and line number, returns the complete enclosing definition
+    (function, method, class, struct, etc.) containing that line. Use depth=2
+    to get the parent definition (e.g., the class containing a method).
+    Falls back to a centered context window for unsupported languages or
+    top-level code.
+
+    Parameters:
+    - absolute_file_path: Absolute path to the file
+    - line: Line number to find the enclosing definition for (1-indexed)
+    - depth: Nesting depth: 1 = innermost, 2 = parent definition
+    - context_lines: Lines of context for fallback window
+
+    Returns:
+    - Content of the enclosing definition with metadata
+    """
+    canonical_path = normalize_path(absolute_file_path)
+
+    # Validate parameters
+    if line < 1:
+        raise ToolError("line must be >= 1.")
+    if depth < 1:
+        raise ToolError("depth must be >= 1.")
+    if context_lines < 1:
+        raise ToolError("context_lines must be >= 1.")
+
+    lines = read_file_lines(canonical_path)
+    content = read_file_content(canonical_path)
+    total_lines = len(lines)
+
+    if line > total_lines:
+        raise ToolError(f"line {line} is beyond end of file ({total_lines} lines).")
+
+    result = find_enclosing_definition(canonical_path, content, line, depth)
+
+    if result is not None:
+        content_text, start_line, end_line, symbol_label = result
+        return {
+            "content": content_text,
+            "start_line": start_line,
+            "end_line": end_line,
+            "lines_returned": end_line - start_line + 1,
+            "total_lines": total_lines,
+            "mode": "enclosing",
+            "enclosing_symbol": symbol_label,
+        }
+
+    # Fallback: centered context window
+    start = max(1, line - context_lines // 2)
+    end = min(total_lines, start + context_lines - 1)
+    content_text = "".join(lines[start - 1 : end])
+    return {
+        "content": content_text,
+        "start_line": start,
+        "end_line": end,
+        "lines_returned": end - start + 1,
+        "total_lines": total_lines,
+        "mode": "context_window",
+        "enclosing_symbol": None,
+    }
 
 
 def _change_result_to_dict(r: ChangeResult) -> dict:

--- a/src/tools.py
+++ b/src/tools.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from mcp.server.fastmcp.exceptions import ToolError
 
+from .change_marker import mark_outline, parse_changed_lines
 from .config import config
 from .data_models import (
     BackupInfo,
@@ -20,6 +21,7 @@ from .data_models import (
     DirectorySearchResult,
     FileOverview,
     LongLineStats,
+    OutlineItem,
     SearchResult,
 )
 from .editor import batch_edit_content
@@ -81,7 +83,10 @@ def handle_tool_errors(func: Callable) -> Callable:
 
 
 @handle_tool_errors
-def get_overview(absolute_file_path: str) -> dict:
+def get_overview(
+    absolute_file_path: str,
+    changed_lines: list[list[int | str]] | None = None,
+) -> dict:
     """Get file structure with basic analysis using auto-detected encoding.
 
     Provides file metadata, line count, and basic structure analysis.
@@ -105,6 +110,8 @@ def get_overview(absolute_file_path: str) -> dict:
     is_binary, binary_hint = is_binary_file(canonical_path)
 
     if is_binary:
+        if changed_lines is not None:
+            raise ToolError("changed_lines not supported for binary files")
         # Return early for binary files
         long_lines_stats = LongLineStats(
             has_long_lines=False,
@@ -161,6 +168,16 @@ def get_overview(absolute_file_path: str) -> dict:
 
     # Generate search hints based on file type
     file_ext = Path(canonical_path).suffix.lower()
+
+    # Mark changed symbols if changed_lines provided
+    changed_count = 0
+    if changed_lines is not None:
+        try:
+            parsed_ranges = parse_changed_lines(changed_lines)
+        except ValueError as e:
+            raise ToolError(f"Invalid changed_lines: {e}") from e
+        outline, changed_count = mark_outline(outline, parsed_ranges)
+
     if file_ext == ".py":
         search_hints = ["def ", "class ", "import ", "from "]
     elif file_ext in [".js", ".ts", ".jsx", ".tsx"]:
@@ -198,17 +215,26 @@ def get_overview(absolute_file_path: str) -> dict:
             "threshold": overview.long_lines.threshold,
         },
         "outline": [
-            {
-                "name": item.name,
-                "type": item.type,
-                "line_number": item.line_number,
-                "end_line": item.end_line,
-                "line_count": item.line_count,
-            }
+            _serialize_outline_item(item, include_changes=changed_lines is not None)
             for item in overview.outline
         ],
         "search_hints": overview.search_hints,
+        **({"changed_symbols": changed_count} if changed_lines is not None else {}),
     }
+
+
+def _serialize_outline_item(item: OutlineItem, include_changes: bool) -> dict:
+    """Serialize an OutlineItem to a flat dict, optionally including changes."""
+    d: dict[str, Any] = {
+        "name": item.name,
+        "type": item.type,
+        "line_number": item.line_number,
+        "end_line": item.end_line,
+        "line_count": item.line_count,
+    }
+    if include_changes:
+        d["changes"] = item.changes
+    return d
 
 
 @handle_tool_errors

--- a/src/tree_parser.py
+++ b/src/tree_parser.py
@@ -7,6 +7,27 @@ from .config import config
 from .data_models import OutlineItem
 from .exceptions import TreeSitterError
 
+# Node types that represent definitions (functions, classes, methods, etc.)
+DEFINITION_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "function_definition",
+        "class_definition",
+        "method_definition",
+        "class_declaration",
+        "method_declaration",
+        "constructor_declaration",
+        "struct_item",
+        "struct",
+        "impl_item",
+        "impl",
+        "interface_declaration",
+        "enum_declaration",
+        "annotation_type_declaration",
+        "function_declaration",
+        "arrow_function",
+    }
+)
+
 # Language mappings for supported file extensions
 SUPPORTED_LANGUAGES = {
     ".py": "python",
@@ -623,3 +644,132 @@ def get_semantic_chunk(
         end_line = min(len(lines), target_line + 10)
         chunk_lines = lines[start_line - 1 : end_line]
         return "\n".join(chunk_lines), start_line, end_line
+
+
+def _build_definition_label(node: Any, file_path: str) -> str:
+    """Build a human-readable label for a definition node.
+
+    Args:
+        node: Tree-sitter AST node whose type is in DEFINITION_NODE_TYPES.
+        file_path: Path used to disambiguate language-specific labels.
+
+    Returns:
+        A label string such as ``"def process_data()"``.
+    """
+    node_type = node.type
+    name: str | None = None
+
+    if node_type in ("function_definition", "method_definition"):
+        name = extract_node_name(node, ("identifier", "property_identifier"))
+        return f"def {name}()" if name else "def ()"
+
+    if node_type in ("class_definition", "class_declaration"):
+        name = extract_node_name(node, "identifier")
+        return f"class {name}" if name else "class"
+
+    if node_type == "method_declaration":
+        name = extract_node_name(node, "identifier")
+        return f"{name}()" if name else "method()"
+
+    if node_type == "constructor_declaration":
+        name = extract_node_name(node, "identifier")
+        return f"constructor {name}()" if name else "constructor()"
+
+    if node_type in ("struct_item", "struct"):
+        name = extract_node_name(node, ("type_identifier", "identifier"))
+        return f"struct {name}" if name else "struct"
+
+    if node_type in ("impl_item", "impl"):
+        return "impl block"
+
+    if node_type == "interface_declaration":
+        name = extract_node_name(node, ("type_identifier", "identifier"))
+        return f"interface {name}" if name else "interface"
+
+    if node_type == "enum_declaration":
+        name = extract_node_name(node, "identifier")
+        return f"enum {name}" if name else "enum"
+
+    if node_type == "annotation_type_declaration":
+        name = extract_node_name(node, "identifier")
+        return f"@interface {name}" if name else "@interface"
+
+    if node_type == "function_declaration":
+        name = extract_node_name(node, "identifier")
+        ext = Path(file_path).suffix.lower()
+        if ext == ".go":
+            return f"func {name}()" if name else "func()"
+        return f"function {name}()" if name else "function()"
+
+    if node_type == "arrow_function":
+        # Name comes from a parent variable_declarator node
+        parent = node.parent
+        if parent and parent.type == "variable_declarator":
+            name = extract_node_name(parent, "identifier")
+        return f"const {name}()" if name else "const ()"
+
+    return str(node_type)
+
+
+def find_enclosing_definition(
+    file_path: str,
+    content: str,
+    target_line: int,
+    depth: int = 1,
+) -> tuple[str, int, int, str] | None:
+    """Walk up the AST from a target line to find the nearest enclosing definition.
+
+    Args:
+        file_path: Path to the file (used for language detection).
+        content: Full text content of the file.
+        target_line: 1-indexed line number to start from.
+        depth: How many definition levels to walk up. ``depth=1`` returns the
+            innermost enclosing definition; ``depth=2`` returns the next one
+            up (e.g. the class containing a method). If depth exceeds available
+            nesting, the outermost definition found is returned.
+
+    Returns:
+        ``(content_text, start_line, end_line, symbol_label)`` where lines are
+        1-indexed, or ``None`` if no enclosing definition is found.
+    """
+    try:
+        tree = parse_file_content(file_path, content)
+        if tree is None:
+            return None
+
+        root_node = tree.root_node
+        # find_node_at_line uses 0-indexed lines
+        current_node = find_node_at_line(root_node, target_line - 1)
+        if current_node is None:
+            return None
+
+        # Walk up to find definition nodes
+        found_node: Any = None
+        definitions_found = 0
+        node = current_node
+
+        while node is not None and node != root_node:
+            if node.type in DEFINITION_NODE_TYPES:
+                definitions_found += 1
+                found_node = node
+                if definitions_found >= depth:
+                    break
+            node = node.parent
+
+        if found_node is None:
+            return None
+
+        # Extract content text
+        start_line_0 = found_node.start_point[0]
+        end_line_0 = found_node.end_point[0]
+        lines = content.splitlines()
+        content_text = "\n".join(lines[start_line_0 : end_line_0 + 1])
+
+        # Build label
+        symbol_label = _build_definition_label(found_node, file_path)
+
+        # Convert to 1-indexed
+        return (content_text, start_line_0 + 1, end_line_0 + 1, symbol_label)
+
+    except Exception:
+        return None

--- a/tests/integration/test_get_overview_diff.py
+++ b/tests/integration/test_get_overview_diff.py
@@ -1,0 +1,190 @@
+"""Integration tests for get_overview with changed_lines parameter.
+
+Verifies that diff-aware change marking works end-to-end through the
+get_overview tool, including backward compatibility, tree-sitter outlines,
+simple outlines, error handling, and binary file rejection.
+"""
+
+from pathlib import Path
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.tools import get_overview
+
+
+class TestGetOverviewDiff:
+    """Integration tests for the changed_lines parameter on get_overview."""
+
+    @property
+    def test_data_dir(self):
+        return Path(__file__).parent.parent / "test_data"
+
+    # ------------------------------------------------------------------ #
+    # Backward compatibility
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_without_changed_lines(self, tmp_path: Path):
+        """Calling without changed_lines preserves existing behavior."""
+        py_file = tmp_path / "sample.py"
+        py_file.write_text(
+            "def greet(name):\n"
+            "    return f'Hello, {name}'\n"
+            "\n"
+            "def farewell(name):\n"
+            "    return f'Goodbye, {name}'\n"
+        )
+
+        result = get_overview(str(py_file))
+
+        # No changes field on any outline item
+        for item in result["outline"]:
+            assert "changes" not in item
+
+        # No changed_symbols key in the response
+        assert "changed_symbols" not in result
+
+    # ------------------------------------------------------------------ #
+    # Tree-sitter outline (Python)
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_with_changed_lines_python(self, tmp_path: Path):
+        """changed_lines marks the correct symbols in a Python file."""
+        py_file = tmp_path / "funcs.py"
+        py_file.write_text(
+            "def alpha():\n"  # line 1
+            "    pass\n"  # line 2
+            "\n"  # line 3
+            "def beta():\n"  # line 4
+            "    pass\n"  # line 5
+            "\n"  # line 6
+            "def gamma():\n"  # line 7
+            "    pass\n"  # line 8
+        )
+
+        # Mark lines 4-5 as modified (covers beta)
+        result = get_overview(str(py_file), changed_lines=[[4, 5, "modified"]])
+
+        assert "changed_symbols" in result
+        assert result["changed_symbols"] >= 1
+
+        # Every outline item must carry a 'changes' key
+        for item in result["outline"]:
+            assert "changes" in item
+
+        # Find beta - it should be marked modified
+        beta_items = [i for i in result["outline"] if "beta" in i["name"]]
+        assert beta_items, "beta should appear in the outline"
+        assert beta_items[0]["changes"] == "modified"
+
+        # alpha should be unaffected
+        alpha_items = [i for i in result["outline"] if "alpha" in i["name"]]
+        if alpha_items:
+            assert alpha_items[0]["changes"] is None
+
+    # ------------------------------------------------------------------ #
+    # "added" change type
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_with_changed_lines_added(self, tmp_path: Path):
+        """A function fully covered by an 'added' range gets changes='added'."""
+        py_file = tmp_path / "added.py"
+        py_file.write_text(
+            "def existing():\n"  # line 1
+            "    pass\n"  # line 2
+            "\n"  # line 3
+            "def brand_new():\n"  # line 4
+            "    return 42\n"  # line 5
+        )
+
+        # Mark lines 4-5 as added (fully covers brand_new)
+        result = get_overview(str(py_file), changed_lines=[[4, 5, "added"]])
+
+        new_items = [i for i in result["outline"] if "brand_new" in i["name"]]
+        assert new_items, "brand_new should appear in the outline"
+        assert new_items[0]["changes"] == "added"
+
+    # ------------------------------------------------------------------ #
+    # Simple (non-tree-sitter) outline
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_with_changed_lines_simple_outline(self, tmp_path: Path):
+        """Non-tree-sitter files still get their simple outline items marked."""
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text(
+            "# Section One\n"  # line 1
+            "some text\n"  # line 2
+            "\n"  # line 3
+            "# Section Two\n"  # line 4
+            "more text\n"  # line 5
+        )
+
+        result = get_overview(str(txt_file), changed_lines=[[1, 2, "modified"]])
+
+        # changed_symbols should exist in the response
+        assert "changed_symbols" in result
+
+        # All outline items should have the changes key
+        for item in result["outline"]:
+            assert "changes" in item
+
+    # ------------------------------------------------------------------ #
+    # Error handling: invalid changed_lines
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_invalid_changed_lines_bad_type(self, tmp_path: Path):
+        """Non-list element in changed_lines raises ToolError."""
+        py_file = tmp_path / "err.py"
+        py_file.write_text("x = 1\n")
+
+        with pytest.raises(ToolError, match="Invalid changed_lines"):
+            get_overview(str(py_file), changed_lines=["bad"])  # type: ignore[list-item]
+
+    def test_get_overview_invalid_changed_lines_start_gt_end(self, tmp_path: Path):
+        """start > end in a range raises ToolError."""
+        py_file = tmp_path / "err2.py"
+        py_file.write_text("x = 1\n")
+
+        with pytest.raises(ToolError, match="Invalid changed_lines"):
+            get_overview(str(py_file), changed_lines=[[10, 5]])
+
+    def test_get_overview_invalid_changed_lines_empty_inner(self, tmp_path: Path):
+        """An empty inner list raises ToolError."""
+        py_file = tmp_path / "err3.py"
+        py_file.write_text("x = 1\n")
+
+        with pytest.raises(ToolError, match="Invalid changed_lines"):
+            get_overview(str(py_file), changed_lines=[[]])  # type: ignore[list-item]
+
+    # ------------------------------------------------------------------ #
+    # Binary file rejection
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_binary_file_with_changed_lines(self, tmp_path: Path):
+        """Providing changed_lines for a binary file raises ToolError."""
+        bin_file = tmp_path / "image.png"
+        # Write a minimal PNG header to trigger binary detection
+        bin_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+        with pytest.raises(ToolError, match="changed_lines not supported for binary"):
+            get_overview(str(bin_file), changed_lines=[[1, 5]])
+
+    # ------------------------------------------------------------------ #
+    # Two-element default type
+    # ------------------------------------------------------------------ #
+
+    def test_get_overview_two_element_default_type(self, tmp_path: Path):
+        """Two-element changed_lines entries default to 'modified'."""
+        py_file = tmp_path / "defaults.py"
+        py_file.write_text(
+            "def only_func():\n"  # line 1
+            "    return True\n"  # line 2
+        )
+
+        # No type specified - should default to "modified"
+        result = get_overview(str(py_file), changed_lines=[[1, 2]])
+
+        func_items = [i for i in result["outline"] if "only_func" in i["name"]]
+        assert func_items, "only_func should appear in the outline"
+        assert func_items[0]["changes"] == "modified"
+        assert result["changed_symbols"] >= 1

--- a/tests/integration/test_get_overview_diff.py
+++ b/tests/integration/test_get_overview_diff.py
@@ -112,14 +112,17 @@ class TestGetOverviewDiff:
         """Non-tree-sitter files still get their simple outline items marked."""
         txt_file = tmp_path / "notes.txt"
         txt_file.write_text(
-            "# Section One\n"  # line 1
+            "TODO: Section One\n"  # line 1
             "some text\n"  # line 2
             "\n"  # line 3
-            "# Section Two\n"  # line 4
+            "FIXME: Section Two\n"  # line 4
             "more text\n"  # line 5
         )
 
         result = get_overview(str(txt_file), changed_lines=[[1, 2, "modified"]])
+
+        # Outline must be non-empty so the loop below is not vacuous
+        assert len(result["outline"]) > 0
 
         # changed_symbols should exist in the response
         assert "changed_symbols" in result
@@ -127,6 +130,9 @@ class TestGetOverviewDiff:
         # All outline items should have the changes key
         for item in result["outline"]:
             assert "changes" in item
+
+        # At least one item should actually be marked as changed
+        assert any(item["changes"] is not None for item in result["outline"])
 
     # ------------------------------------------------------------------ #
     # Error handling: invalid changed_lines

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -11,6 +11,7 @@ EXPECTED_TOOLS = {
     "get_overview",
     "search_content",
     "read_content",
+    "read_enclosing",
     "edit_content",
     "revert_edit",
     "list_directory",
@@ -21,6 +22,7 @@ READ_ONLY_TOOLS = {
     "get_overview",
     "search_content",
     "read_content",
+    "read_enclosing",
     "list_directory",
     "search_directory",
 }
@@ -37,7 +39,7 @@ class TestMCPServer:
         assert mcp.name == "largefile"
 
     def test_all_tools_registered(self):
-        """All 7 tools are registered."""
+        """All 8 tools are registered."""
         tools = mcp._tool_manager.list_tools()
         tool_names = {t.name for t in tools}
         assert tool_names == EXPECTED_TOOLS

--- a/tests/integration/test_read_enclosing.py
+++ b/tests/integration/test_read_enclosing.py
@@ -1,0 +1,45 @@
+"""Integration tests for read_enclosing tool.
+
+End-to-end tests exercising the full tool path for enclosing definition
+lookup and fallback context window.
+"""
+
+from pathlib import Path
+
+from src.tools import read_enclosing
+
+
+class TestReadEnclosingIntegration:
+    """Integration tests for the read_enclosing tool."""
+
+    @property
+    def test_data_dir(self) -> Path:
+        return Path(__file__).parent.parent / "test_data"
+
+    def test_enclosing_read_on_python_file(self):
+        """Enclosing read returns correct dict shape for a Python function."""
+        python_file = self.test_data_dir / "python" / "django-models.py"
+        # Line 62 is inside __repr__ of the Deferred class
+        result = read_enclosing(str(python_file), line=62)
+
+        assert isinstance(result["content"], str)
+        assert len(result["content"]) > 0
+        assert isinstance(result["start_line"], int)
+        assert isinstance(result["end_line"], int)
+        assert result["start_line"] <= result["end_line"]
+        assert result["mode"] == "enclosing"
+        assert isinstance(result["enclosing_symbol"], str)
+        assert len(result["enclosing_symbol"]) > 0
+        assert result["lines_returned"] == result["end_line"] - result["start_line"] + 1
+        assert result["total_lines"] > 0
+
+    def test_fallback_on_non_code_file(self):
+        """Fallback returns context_window mode for non-code files."""
+        md_file = self.test_data_dir / "markdown" / "fastapi-docs.md"
+        result = read_enclosing(str(md_file), line=5, context_lines=20)
+
+        assert result["mode"] == "context_window"
+        assert result["enclosing_symbol"] is None
+        assert isinstance(result["content"], str)
+        assert len(result["content"]) > 0
+        assert result["lines_returned"] <= 20

--- a/tests/test_data/javascript/nested_arrow.js
+++ b/tests/test_data/javascript/nested_arrow.js
@@ -1,0 +1,24 @@
+/**
+ * Test fixture with class methods and arrow functions.
+ */
+
+class EventEmitter {
+    constructor() {
+        this.listeners = {};
+    }
+
+    on(event, callback) {
+        if (!this.listeners[event]) {
+            this.listeners[event] = [];
+        }
+        this.listeners[event].push(callback);
+    }
+}
+
+const handleRequest = (req, res) => {
+    const body = req.body;
+    res.send(body);
+};
+
+// Top-level code (not inside any definition)
+const x = 1;

--- a/tests/test_data/python/nested_class.py
+++ b/tests/test_data/python/nested_class.py
@@ -1,0 +1,27 @@
+"""Test fixture with nested class/method structures."""
+
+
+def helper():
+    """Standalone function outside any class."""
+    return 42
+
+
+class DataProcessor:
+    """A class with two methods for testing enclosing definition lookup."""
+
+    def process(self, data):
+        """Process the given data."""
+        result = []
+        for item in data:
+            result.append(item * 2)
+        return result
+
+    def validate(self, data):
+        """Validate the given data."""
+        if not data:
+            return False
+        return all(isinstance(item, int) for item in data)
+
+
+# Top-level code (not inside any definition)
+x = 1

--- a/tests/unit/test_change_marker.py
+++ b/tests/unit/test_change_marker.py
@@ -1,0 +1,261 @@
+"""Unit tests for the change_marker module.
+
+Covers parse_changed_lines, classify_change, mark_outline,
+and the changed_count return value.
+"""
+
+import pytest
+
+from src.change_marker import classify_change, mark_outline, parse_changed_lines
+from src.data_models import OutlineItem
+
+# ---------------------------------------------------------------------------
+# parse_changed_lines
+# ---------------------------------------------------------------------------
+
+
+class TestParseChangedLines:
+    """Validation, sorting, and merging of raw changed-line input."""
+
+    def test_two_element_defaults_to_modified(self):
+        result = parse_changed_lines([[10, 15]])
+        assert result == [(10, 15, "modified")]
+
+    def test_three_element_preserves_type(self):
+        result = parse_changed_lines([[10, 15, "added"]])
+        assert result == [(10, 15, "added")]
+
+    def test_mixed_two_and_three_element(self):
+        result = parse_changed_lines([[1, 5], [10, 20, "removed"]])
+        assert result == [(1, 5, "modified"), (10, 20, "removed")]
+
+    def test_invalid_start_greater_than_end(self):
+        with pytest.raises(ValueError, match="start.*<=.*end"):
+            parse_changed_lines([[15, 10]])
+
+    def test_invalid_negative_start(self):
+        with pytest.raises(ValueError, match="start must be >= 1"):
+            parse_changed_lines([[0, 5]])
+
+    def test_invalid_bad_type_string(self):
+        with pytest.raises(ValueError, match="type must be one of"):
+            parse_changed_lines([[1, 5, "deleted"]])
+
+    def test_invalid_wrong_length_one(self):
+        with pytest.raises(ValueError, match="2 or 3 elements"):
+            parse_changed_lines([[5]])
+
+    def test_invalid_wrong_length_four(self):
+        with pytest.raises(ValueError, match="2 or 3 elements"):
+            parse_changed_lines([[1, 2, "added", "extra"]])
+
+    def test_invalid_non_integer_start(self):
+        with pytest.raises(ValueError, match="integers"):
+            parse_changed_lines([["a", 5]])
+
+    def test_invalid_non_integer_end(self):
+        with pytest.raises(ValueError, match="integers"):
+            parse_changed_lines([[1, "b"]])
+
+    def test_sorting_unsorted_input(self):
+        result = parse_changed_lines([[20, 25], [1, 5], [10, 15]])
+        starts = [r[0] for r in result]
+        assert starts == [1, 10, 20]
+
+    def test_merge_adjacent_same_type(self):
+        # 1-5 and 6-10 are adjacent (end >= start - 1)
+        result = parse_changed_lines([[1, 5], [6, 10]])
+        assert result == [(1, 10, "modified")]
+
+    def test_merge_overlapping_same_type(self):
+        result = parse_changed_lines([[1, 8], [5, 12]])
+        assert result == [(1, 12, "modified")]
+
+    def test_no_merge_different_type_overlapping(self):
+        result = parse_changed_lines([[1, 10, "added"], [5, 15, "modified"]])
+        assert len(result) == 2
+        assert result[0] == (1, 10, "added")
+        assert result[1] == (5, 15, "modified")
+
+    def test_empty_input(self):
+        result = parse_changed_lines([])
+        assert result == []
+
+    def test_single_line_range(self):
+        result = parse_changed_lines([[5, 5]])
+        assert result == [(5, 5, "modified")]
+
+    def test_merge_multiple_adjacent(self):
+        result = parse_changed_lines([[1, 2], [3, 4], [5, 6]])
+        assert result == [(1, 6, "modified")]
+
+
+# ---------------------------------------------------------------------------
+# classify_change
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyChange:
+    """Overlap detection and classification logic."""
+
+    def test_fully_inside_added_range(self):
+        ranges = [(1, 20, "added")]
+        assert classify_change(5, 10, ranges) == "added"
+
+    def test_fully_covered_by_multiple_adjacent_added(self):
+        ranges = [(1, 5, "added"), (6, 10, "added")]
+        assert classify_change(1, 10, ranges) == "added"
+
+    def test_partially_overlapping_added_not_fully_covered(self):
+        ranges = [(5, 10, "added")]
+        assert classify_change(1, 10, ranges) == "modified"
+
+    def test_only_removed_ranges(self):
+        ranges = [(1, 10, "removed")]
+        assert classify_change(3, 7, ranges) == "removed"
+
+    def test_mixed_added_and_modified(self):
+        ranges = [(1, 5, "added"), (6, 10, "modified")]
+        assert classify_change(1, 10, ranges) == "modified"
+
+    def test_no_overlap(self):
+        ranges = [(1, 5, "modified")]
+        assert classify_change(10, 20, ranges) is None
+
+    def test_single_line_symbol_overlapping(self):
+        ranges = [(5, 10, "added")]
+        assert classify_change(5, 5, ranges) == "added"
+
+    def test_single_line_symbol_no_overlap(self):
+        ranges = [(5, 10, "added")]
+        assert classify_change(4, 4, ranges) is None
+
+    def test_symbol_spanning_multiple_same_type(self):
+        ranges = [(1, 3, "modified"), (7, 10, "modified")]
+        assert classify_change(1, 10, ranges) == "modified"
+
+    def test_empty_ranges(self):
+        assert classify_change(1, 10, []) is None
+
+    def test_symbol_exactly_matches_range(self):
+        ranges = [(5, 10, "added")]
+        assert classify_change(5, 10, ranges) == "added"
+
+    def test_removed_multiple_ranges(self):
+        ranges = [(1, 5, "removed"), (8, 12, "removed")]
+        assert classify_change(1, 12, ranges) == "removed"
+
+    def test_added_with_gap_means_modified(self):
+        # Two added ranges that don't fully cover the symbol
+        ranges = [(1, 3, "added"), (7, 10, "added")]
+        assert classify_change(1, 10, ranges) == "modified"
+
+
+# ---------------------------------------------------------------------------
+# mark_outline
+# ---------------------------------------------------------------------------
+
+
+def _make_item(name: str, line_start: int, line_end: int) -> OutlineItem:
+    """Helper to create a minimal OutlineItem."""
+    return OutlineItem(
+        name=name,
+        type="function",
+        line_number=line_start,
+        end_line=line_end,
+        children=[],
+        line_count=line_end - line_start + 1,
+    )
+
+
+class TestMarkOutline:
+    """Flat outline marking and count tracking."""
+
+    def test_some_items_overlap(self):
+        items = [_make_item("a", 1, 10), _make_item("b", 20, 30)]
+        ranges = [(5, 15, "modified")]
+        result_items, count = mark_outline(items, ranges)
+        assert result_items[0].changes == "modified"
+        assert result_items[1].changes is None
+        assert count == 1
+
+    def test_empty_outline(self):
+        items, count = mark_outline([], [(1, 10, "modified")])
+        assert items == []
+        assert count == 0
+
+    def test_no_overlap_all_none(self):
+        items = [_make_item("a", 1, 5), _make_item("b", 10, 15)]
+        ranges = [(50, 60, "added")]
+        _, count = mark_outline(items, ranges)
+        assert count == 0
+        assert all(item.changes is None for item in items)
+
+    def test_multiple_items_multiple_ranges(self):
+        items = [
+            _make_item("a", 1, 10),
+            _make_item("b", 15, 25),
+            _make_item("c", 30, 40),
+        ]
+        ranges = [(1, 10, "added"), (20, 22, "modified")]
+        result_items, count = mark_outline(items, ranges)
+        assert result_items[0].changes == "added"
+        assert result_items[1].changes == "modified"
+        assert result_items[2].changes is None
+        assert count == 2
+
+    def test_does_not_recurse_into_children(self):
+        """Children in the flat list are separate top-level entries.
+
+        mark_outline should not touch item.children directly.
+        """
+        child = _make_item("child", 5, 8)
+        parent = OutlineItem(
+            name="parent",
+            type="class",
+            line_number=1,
+            end_line=20,
+            children=[child],
+            line_count=20,
+        )
+        # Only pass the parent, not the child (simulating non-flattened case)
+        # child should remain untouched
+        ranges = [(1, 20, "modified")]
+        result_items, count = mark_outline([parent], ranges)
+        assert result_items[0].changes == "modified"
+        # The child was NOT in the top-level list, so it stays None
+        assert child.changes is None
+        assert count == 1
+
+    def test_mutates_in_place(self):
+        items = [_make_item("a", 1, 10)]
+        ranges = [(1, 10, "added")]
+        result_items, _ = mark_outline(items, ranges)
+        assert result_items is items
+        assert items[0].changes == "added"
+
+
+class TestMarkOutlineChangedCount:
+    """Verify returned count matches items with non-None changes."""
+
+    def test_count_matches_marked_items(self):
+        items = [
+            _make_item("a", 1, 10),
+            _make_item("b", 15, 25),
+            _make_item("c", 30, 40),
+            _make_item("d", 50, 60),
+        ]
+        ranges = [(1, 10, "added"), (30, 40, "removed")]
+        _, count = mark_outline(items, ranges)
+        marked = sum(1 for item in items if item.changes is not None)
+        assert count == marked == 2
+
+    def test_count_zero_when_no_changes(self):
+        items = [_make_item("a", 1, 10)]
+        _, count = mark_outline(items, [(100, 200, "modified")])
+        assert count == 0
+
+    def test_count_all_when_everything_changed(self):
+        items = [_make_item("a", 1, 10), _make_item("b", 11, 20)]
+        _, count = mark_outline(items, [(1, 20, "modified")])
+        assert count == 2

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -16,6 +16,7 @@ from src.tools import (
     edit_content,
     get_overview,
     read_content,
+    read_enclosing,
     search_content,
 )
 
@@ -437,3 +438,113 @@ class TestSearchContentEdgeCases:
             assert result["total_matches"] > 0
             # Context should fall back to line number
             assert "Line" in result["results"][0]["semantic_context"]
+
+
+class TestReadEnclosing:
+    """Test read_enclosing tool function."""
+
+    @pytest.fixture
+    def python_file(self, tmp_path):
+        """Create a Python file with nested class and method."""
+        content = (
+            "import os\n"
+            "\n"
+            "TOP_LEVEL = 42\n"
+            "\n"
+            "class MyClass:\n"
+            "    def method_one(self):\n"
+            "        x = 1\n"
+            "        y = 2\n"
+            "        return x + y\n"
+            "\n"
+            "    def method_two(self):\n"
+            "        return 'hello'\n"
+            "\n"
+            "def standalone():\n"
+            "    pass\n"
+        )
+        file = tmp_path / "sample.py"
+        file.write_text(content)
+        return str(file)
+
+    @pytest.fixture
+    def yaml_file(self, tmp_path):
+        """Create a YAML file (not supported by tree-sitter)."""
+        content = "key: value\nlist:\n  - item1\n  - item2\n  - item3\n"
+        file = tmp_path / "config.yaml"
+        file.write_text(content)
+        return str(file)
+
+    def test_enclosing_read_python_function(self, python_file):
+        """Successful enclosing read on Python file returns enclosing mode."""
+        # Line 7 is inside method_one
+        result = read_enclosing(python_file, line=7)
+
+        assert result["mode"] == "enclosing"
+        assert result["enclosing_symbol"] is not None
+        assert isinstance(result["enclosing_symbol"], str)
+        assert len(result["enclosing_symbol"]) > 0
+        assert isinstance(result["start_line"], int)
+        assert isinstance(result["end_line"], int)
+        assert result["start_line"] <= 7 <= result["end_line"]
+        assert len(result["content"]) > 0
+        assert result["lines_returned"] == result["end_line"] - result["start_line"] + 1
+
+    def test_fallback_non_treesitter_file(self, yaml_file):
+        """Fallback to context window for non-tree-sitter file."""
+        result = read_enclosing(yaml_file, line=2)
+
+        assert result["mode"] == "context_window"
+        assert result["enclosing_symbol"] is None
+        assert len(result["content"]) > 0
+
+    def test_fallback_toplevel_code(self, python_file):
+        """Fallback to context window for top-level code."""
+        # Line 3 is TOP_LEVEL = 42, not inside any function or class
+        result = read_enclosing(python_file, line=3)
+
+        assert result["mode"] == "context_window"
+        assert result["enclosing_symbol"] is None
+
+    @pytest.mark.parametrize(
+        "line,error_msg",
+        [
+            (0, "line must be >= 1"),
+            (-1, "line must be >= 1"),
+        ],
+    )
+    def test_invalid_line_numbers(self, python_file, line, error_msg):
+        """Invalid line numbers raise ToolError."""
+        with pytest.raises(ToolError, match=error_msg):
+            read_enclosing(python_file, line=line)
+
+    def test_line_beyond_file(self, python_file):
+        """Line beyond file length raises ToolError."""
+        with pytest.raises(ToolError, match="beyond end of file"):
+            read_enclosing(python_file, line=9999)
+
+    def test_depth_2_returns_class(self, python_file):
+        """depth=2 on method inside class returns the class."""
+        # Line 7 is inside method_one which is inside MyClass
+        result = read_enclosing(python_file, line=7, depth=2)
+
+        assert result["mode"] == "enclosing"
+        assert result["enclosing_symbol"] is not None
+        # The enclosing symbol at depth=2 should be the class
+        assert (
+            "class" in result["enclosing_symbol"].lower()
+            or "MyClass" in result["enclosing_symbol"]
+        )
+        # The range should encompass the entire class
+        assert result["start_line"] <= 5  # class starts at line 5
+        assert result["end_line"] >= 12  # class ends at line 12
+
+    def test_context_lines_parameter(self, yaml_file):
+        """context_lines parameter adjusts fallback window size."""
+        result_small = read_enclosing(yaml_file, line=3, context_lines=2)
+        result_large = read_enclosing(yaml_file, line=3, context_lines=10)
+
+        assert result_small["mode"] == "context_window"
+        assert result_large["mode"] == "context_window"
+        assert result_small["lines_returned"] <= 2
+        assert result_large["lines_returned"] >= result_small["lines_returned"]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -548,3 +548,15 @@ class TestReadEnclosing:
         assert result_large["mode"] == "context_window"
         assert result_small["lines_returned"] <= 2
         assert result_large["lines_returned"] >= result_small["lines_returned"]
+
+    def test_context_window_backfills_near_eof(self, yaml_file):
+        """Near EOF, context window shifts start backward to fill requested size."""
+        # yaml_file has 5 lines; requesting line=5 with context_lines=4
+        # Without backfill: start=4, end=5, window=2
+        # With backfill: start=2, end=5, window=4
+        result = read_enclosing(yaml_file, line=5, context_lines=4)
+
+        assert result["mode"] == "context_window"
+        assert result["lines_returned"] == 4
+        assert result["end_line"] == 5
+        assert result["start_line"] == 2

--- a/tests/unit/test_tree_parser.py
+++ b/tests/unit/test_tree_parser.py
@@ -9,10 +9,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.tree_parser import (
+    DEFINITION_NODE_TYPES,
     SUPPORTED_LANGUAGES,
     create_outline_item_from_node,
     extract_node_name,
     extract_semantic_context,
+    find_enclosing_definition,
     generate_outline,
     generate_simple_outline,
     get_language_parser,
@@ -474,3 +476,112 @@ class TestJavaSupport:
             # When tree-sitter is active, methods must also be in the flat list
             method_items = [item for item in outline if item.type == "method"]
             assert len(method_items) >= 1
+
+
+class TestFindEnclosingDefinition:
+    """Tests for find_enclosing_definition()."""
+
+    PYTHON_FIXTURE = "tests/test_data/python/nested_class.py"
+    JS_FIXTURE = "tests/test_data/javascript/nested_arrow.js"
+
+    @staticmethod
+    def _read_fixture(path: str) -> str:
+        with open(path) as f:
+            return f.read()
+
+    def test_python_line_inside_function_returns_function(self):
+        """Line inside a standalone function returns that function."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, 6)
+        assert result is not None
+        text, start, end, label = result
+        assert "helper" in label
+        assert "def" in label
+        assert start <= 6 <= end
+        assert "return 42" in text
+
+    def test_python_line_inside_method_returns_method(self):
+        """Line inside a class method returns the method."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        # Line 16: inside process() method - "result.append(item * 2)"
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, 16)
+        assert result is not None
+        text, start, end, label = result
+        assert "process" in label
+        assert "def" in label
+        assert start <= 16 <= end
+
+    def test_python_depth2_on_method_returns_class(self):
+        """depth=2 on a line inside a method returns the enclosing class."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        # Line 16: inside process() method
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, 16, depth=2)
+        assert result is not None
+        text, start, end, label = result
+        assert "class" in label.lower()
+        assert "DataProcessor" in label
+
+    def test_js_arrow_function_returns_correct_name(self):
+        """Arrow function returns correct name from parent variable_declarator."""
+        content = self._read_fixture(self.JS_FIXTURE)
+        # Line 21: inside handleRequest arrow function - "const body = req.body;"
+        result = find_enclosing_definition(self.JS_FIXTURE, content, 21)
+        assert result is not None
+        text, start, end, label = result
+        assert "handleRequest" in label
+        assert "const" in label
+
+    def test_js_class_method_returns_method(self):
+        """Line inside a JS class method returns the method."""
+        content = self._read_fixture(self.JS_FIXTURE)
+        # Line 12: inside on() method - "if (!this.listeners[event])"
+        result = find_enclosing_definition(self.JS_FIXTURE, content, 12)
+        assert result is not None
+        text, start, end, label = result
+        assert "on" in label
+        assert start <= 12 <= end
+
+    def test_top_level_returns_none(self):
+        """Line at top level (no enclosing definition) returns None."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        # Last line: "x = 1" - top-level assignment
+        lines = content.splitlines()
+        last_line = len(lines)
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, last_line)
+        assert result is None
+
+    def test_definition_line_returns_that_function(self):
+        """Line on a function's own definition line returns that function."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        # Line 4: "def helper():" - the definition line itself
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, 4)
+        assert result is not None
+        text, start, end, label = result
+        assert "helper" in label
+        assert start == 4
+
+    def test_depth_exceeding_nesting_returns_outermost(self):
+        """Depth exceeding nesting returns outermost definition, not None."""
+        content = self._read_fixture(self.PYTHON_FIXTURE)
+        # Line 16: inside process() method (depth 2 = class, depth 3 = nothing more)
+        result = find_enclosing_definition(self.PYTHON_FIXTURE, content, 16, depth=10)
+        assert result is not None
+        text, start, end, label = result
+        # Should return the outermost definition found (the class)
+        assert "class" in label.lower() or "DataProcessor" in label
+
+    def test_unsupported_language_returns_none(self):
+        """Unsupported file type returns None without raising."""
+        result = find_enclosing_definition("test.xyz", "some content", 1)
+        assert result is None
+
+    def test_definition_node_types_is_frozenset(self):
+        """DEFINITION_NODE_TYPES is a frozenset with expected entries."""
+        assert isinstance(DEFINITION_NODE_TYPES, frozenset)
+        assert "function_definition" in DEFINITION_NODE_TYPES
+        assert "class_definition" in DEFINITION_NODE_TYPES
+        assert "arrow_function" in DEFINITION_NODE_TYPES
+        assert "function_declaration" in DEFINITION_NODE_TYPES
+        # Should NOT include overly broad types
+        assert "export_statement" not in DEFINITION_NODE_TYPES
+        assert "lexical_declaration" not in DEFINITION_NODE_TYPES

--- a/tests/unit/test_tree_parser.py
+++ b/tests/unit/test_tree_parser.py
@@ -4,6 +4,7 @@ Test core tree-sitter functionality with graceful fallback handling.
 Uses table-driven tests for comprehensive coverage.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -481,13 +482,13 @@ class TestJavaSupport:
 class TestFindEnclosingDefinition:
     """Tests for find_enclosing_definition()."""
 
-    PYTHON_FIXTURE = "tests/test_data/python/nested_class.py"
-    JS_FIXTURE = "tests/test_data/javascript/nested_arrow.js"
+    _TEST_DATA_DIR = str(Path(__file__).resolve().parents[1] / "test_data")
+    PYTHON_FIXTURE = f"{_TEST_DATA_DIR}/python/nested_class.py"
+    JS_FIXTURE = f"{_TEST_DATA_DIR}/javascript/nested_arrow.js"
 
     @staticmethod
     def _read_fixture(path: str) -> str:
-        with open(path) as f:
-            return f.read()
+        return Path(path).read_text(encoding="utf-8")
 
     def test_python_line_inside_function_returns_function(self):
         """Line inside a standalone function returns that function."""


### PR DESCRIPTION
Code review tools that use largefile mcp need to work around reading changed content. They currently have to call get_overview then manually correlate diff ranges with outline symbols, and estimate line ranges to read relevant definitions.  This adds inbuilt capabilities for better navigation:
- `changed_lines` accepts diff ranges (for example as available from [diffchunk](https://github.com/peteretelej/diffchunk)) and classifies each symbol in the outline, so review tools can immediately focus on what changed without a second pass.
- `read_enclosing` uses tree-sitter to walk up the AST and return the complete enclosing definition for any line. Supports configurable nesting depth (e.g. depth=2 for the class containing a method) with a context-window fallback for unsupported languages. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diff-aware overview: get_overview accepts changed line ranges and reports per-symbol change states; added read_enclosing to return enclosing definition or context for a given line.
* **Documentation**
  * Updated API/design docs and examples with diff-aware overview usage and new tool specs; README badge line simplified.
* **Tests**
  * Added integration and unit tests covering diff-aware behavior, read_enclosing, and enclosing-definition discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->